### PR TITLE
Download function fix and file support

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,3 +25,9 @@ Use the `--lucky` flag to download the first one of the list.
 ```
 itasa Breaking Bad 5x13 --lucky
 ```
+
+Use the `--file` flag to download subtitles according to the filename. You can combile `--file` with `--lucky` to get subtitle with the quality provided in the filename. If the filename point to an existing file subtitle(s) will be also copied  in the directory of the file and renamed as filename.srt
+
+```
+itasa /mnt/tv shows/bluray-rip/game.of.thrones.s04e06.720p.hdtv.x264.mkv --file
+```

--- a/README.md
+++ b/README.md
@@ -29,5 +29,5 @@ itasa Breaking Bad 5x13 --lucky
 Use the `--file` flag to download subtitles according to the filename. You can combile `--file` with `--lucky` to get subtitle with the quality provided in the filename. If the filename point to an existing file subtitle(s) will be also copied  in the directory of the file and renamed as filename.srt
 
 ```
-itasa /mnt/tv shows/bluray-rip/game.of.thrones.s04e06.720p.hdtv.x264.mkv --file
+itasa --file /mnt/tv shows/bluray-rip/game.of.thrones.s04e06.720p.hdtv.x264.mkv
 ```

--- a/package.json
+++ b/package.json
@@ -12,8 +12,10 @@
   "dependencies": {
     "chalk": "^1.1.1",
     "configstore": "^1.2.1",
+    "epinfer": "^1.1.4",
     "inquirer": "^0.10.0",
     "request": "^2.61.0",
+    "rimraf": "^2.6.2",
     "underscore": "^1.8.3",
     "unzip": "^0.1.11",
     "yargs": "^3.25.0"


### PR DESCRIPTION
The download function was broken so I adopted the itasa api instead of parsing the html page.
I changed the behaviour of the `--file` switch. It can now parse common tv show filename schemas to obtain some informations used to query itasa. The `associate` function is now called only if `--file` argument is an existing file and then it move and rename the subtitle(s) according to the file path and its filename.